### PR TITLE
fix(#120): Use untrack() in resize Effect to prevent hover-triggered layout reflow

### DIFF
--- a/src/ui/solar_map.rs
+++ b/src/ui/solar_map.rs
@@ -18,6 +18,8 @@ use leptos::SignalGet;
 #[cfg(feature = "web")]
 use leptos::SignalSet;
 #[cfg(feature = "web")]
+use leptos::untrack;
+#[cfg(feature = "web")]
 use leptos::NodeRef;
 #[cfg(feature = "web")]
 use leptos::view;
@@ -385,7 +387,12 @@ pub fn SolarMap(
         hovered_planet.set(None);
     };
 
-    // Set up resize observer effect
+    // Set up resize observer effect.
+    // IMPORTANT: render_canvas() reads `hovered_planet`, so we must wrap it in
+    // `untrack()` here. Without untrack, Leptos would subscribe this resize
+    // Effect to `hovered_planet`, causing every hover to trigger a canvas
+    // resize → layout reflow → vertical panel expansion and broken click coords.
+    let render_canvas_for_resize = render_canvas.clone();
     Effect::new(move |_| {
         let canvas = match canvas_ref.get() {
             Some(c) => c,
@@ -402,9 +409,21 @@ pub fn SolarMap(
             canvas.set_width(width as u32);
             canvas.set_height(height as u32);
 
-            // Initial render
-            render_canvas();
+            // Render without creating reactive subscriptions to hover state.
+            // untrack() prevents signal reads inside render_canvas() from being
+            // tracked by this resize Effect's reactive scope.
+            let render = render_canvas_for_resize.clone();
+            untrack(move || render());
         }
+    });
+
+    // Dedicated hover Effect: re-render the canvas whenever hover state
+    // changes. This is the only Effect that should subscribe to hovered_planet.
+    let render_canvas_for_hover = render_canvas.clone();
+    Effect::new(move |_| {
+        // Explicitly track hovered_planet so this Effect re-runs on hover changes.
+        let _ = hovered_planet.get();
+        render_canvas_for_hover();
     });
 
     view! {


### PR DESCRIPTION
## Summary

- In `src/ui/solar_map.rs`, the resize `Effect` called `render_canvas()` which reads the `hovered_planet` signal (line 220), accidentally subscribing the resize Effect to `hovered_planet` changes.
- Every planet hover triggered the resize Effect → `canvas.set_width/set_height` → layout reflow → vertical panel expansion → broken click coordinates.
- Fix: wrap `render_canvas()` inside the resize Effect with `leptos::untrack()` so signal reads inside `render_canvas()` don't create subscriptions in the resize Effect's reactive scope.
- Add a separate dedicated hover `Effect` that explicitly subscribes to `hovered_planet` and calls `render_canvas()` for hover re-renders only.

## Test plan

- [ ] Start the game with `trunk serve --port 8080`
- [ ] Navigate to http://localhost:8080 and wait for WASM to load
- [ ] Hover over planets on the solar map — panel should NOT expand vertically
- [ ] Click on a hovered planet — selection should register correctly
- [ ] Verify the hover ring still renders visually on the canvas when hovering

Fixes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)