### PR TITLE
Fix: Market panel shows same prices for all planets

### DIFF
--- a/src/ui/market_panel.rs
+++ b/src/ui/market_panel.rs
@@ -67,32 +67,32 @@ pub fn MarketPanel(
 
 /// Market Panel with Signal Support
 ///
-/// This version accepts callbacks that return planet data,
+/// This version accepts reactive signals/memos for planet data,
 /// allowing it to reactively update when the selected planet changes.
 ///
 /// # Arguments
-/// * `get_planet_name` - Callback to get the current planet name
-/// * `get_planet_type` - Callback to get the current planet type (currently unused but accepted for API consistency)
-/// * `get_economy` - Callback to get the current planet economy
+/// * `planet_name` - Callback to get the current planet name (reactive)
+/// * `planet_type` - Memo containing the current planet type (reactive)
+/// * `economy` - Memo containing the current planet economy (reactive)
 #[cfg(feature = "web")]
 #[component]
 pub fn MarketPanelReactive(
-    get_planet_name: Box<dyn Fn() -> String>,
-    get_planet_type: Box<dyn Fn() -> PlanetType>,
-    get_economy: Box<dyn Fn() -> PlanetEconomy>,
+    planet_name: impl Fn() -> String + 'static,
+    planet_type: Memo<PlanetType>,
+    economy: Memo<PlanetEconomy>,
 ) -> impl IntoView {
     // Get all commodity types
     let commodities = CommodityType::all();
 
-    // Note: get_planet_type is available but not currently used in rendering
+    // Note: planet_type is available but not currently used in rendering
     // It's kept for potential future use (e.g., planet type badges)
-    let _ = get_planet_type;
+    let _ = planet_type;
 
     view! {
         <div class="panel market-panel">
             <div class="panel-header">
                 <h3>"Market"</h3>
-                <span class="panel-subtitle">{move || get_planet_name()}</span>
+                <span class="panel-subtitle">{move || planet_name()}</span>
             </div>
             <div class="panel-content">
                 <div class="market-table">
@@ -104,9 +104,9 @@ pub fn MarketPanelReactive(
                     {
                         commodities.into_iter().map(move |commodity| {
                             let commodity_name = commodity.display_name();
-                            let economy = get_economy();
-                            let buy_price = economy.get_buy_price(&commodity).unwrap_or(0);
-                            let sell_price = economy.get_sell_price(&commodity).unwrap_or(0);
+                            let current_economy = economy.get();
+                            let buy_price = current_economy.get_buy_price(&commodity).unwrap_or(0);
+                            let sell_price = current_economy.get_sell_price(&commodity).unwrap_or(0);
 
                             view! {
                                 <div class="market-row">

--- a/src/ui/web.rs
+++ b/src/ui/web.rs
@@ -20,6 +20,12 @@ pub fn App() -> impl IntoView {
     let (cargo_used, _set_cargo_used) = create_signal(0);
     let (selected_planet, set_selected_planet) = create_signal(None::<String>);
 
+    // Create memoized values for reactive planet selection
+    // This ensures the market panel properly tracks when selected_planet changes
+    let current_planet_id = create_memo(move |_| {
+        selected_planet.get().unwrap_or(location.get())
+    });
+
     // Create solar system planet data with economy
     let planets: Vec<Planet> = vec![
         Planet {
@@ -104,6 +110,28 @@ pub fn App() -> impl IntoView {
             economy: PlanetEconomy::new(PlanetType::PirateSpaceStation),
         },
     ];
+
+    // Clone planets for use in reactive memos
+    let planets_for_economy = planets.clone();
+    let planets_for_type = planets.clone();
+
+    // Create memoized economy that reacts to planet selection changes
+    let current_economy = create_memo(move |_| {
+        let planet_id = current_planet_id.get();
+        planets_for_economy.iter()
+            .find(|p| p.id == planet_id)
+            .map(|p| p.economy.clone())
+            .unwrap_or_else(|| PlanetEconomy::new(PlanetType::Agricultural))
+    });
+
+    // Create memoized planet type for reactive updates
+    let current_planet_type = create_memo(move |_| {
+        let planet_id = current_planet_id.get();
+        planets_for_type.iter()
+            .find(|p| p.id == planet_id)
+            .map(|p| p.planet_type.clone())
+            .unwrap_or(PlanetType::Agricultural)
+    });
 
     view! {
         <div class="app-container">
@@ -209,46 +237,9 @@ pub fn App() -> impl IntoView {
 
                     // Market Panel - Reactive component that updates with planet selection
                     <MarketPanelReactive
-                        get_planet_name={Box::new({
-                            let planets_clone = planets.clone();
-                            move || {
-                                let selected_id = selected_planet.get();
-                                let location_id = location.get();
-                                // Use selected planet, or fall back to player location
-                                let planet_id = selected_id.unwrap_or(location_id);
-                                
-                                planets_clone.iter()
-                                    .find(|p| p.id == planet_id)
-                                    .map(|p| p.name.clone())
-                                    .unwrap_or_else(|| "Unknown".to_string())
-                            }
-                        })}
-                        get_planet_type={Box::new({
-                            let planets_clone = planets.clone();
-                            move || {
-                                let selected_id = selected_planet.get();
-                                let location_id = location.get();
-                                let planet_id = selected_id.unwrap_or(location_id);
-                                
-                                planets_clone.iter()
-                                    .find(|p| p.id == planet_id)
-                                    .map(|p| p.planet_type.clone())
-                                    .unwrap_or(PlanetType::Agricultural)
-                            }
-                        })}
-                        get_economy={Box::new({
-                            let planets_clone = planets.clone();
-                            move || {
-                                let selected_id = selected_planet.get();
-                                let location_id = location.get();
-                                let planet_id = selected_id.unwrap_or(location_id);
-                                
-                                planets_clone.iter()
-                                    .find(|p| p.id == planet_id)
-                                    .map(|p| p.economy.clone())
-                                    .unwrap_or_else(|| PlanetEconomy::new(PlanetType::Agricultural))
-                            }
-                        })}
+                        planet_name={move || current_planet_id.get()}
+                        planet_type={current_planet_type}
+                        economy={current_economy}
                     />
                 </div>
             </div>


### PR DESCRIPTION
## Summary

Fixes the bug where all planets displayed identical prices in the market panel, regardless of planet type.

## Root Cause

The `MarketPanelReactive` component used plain closures (`Box<dyn Fn()>`) that captured economy data at creation time. When the `selected_planet` signal changed, the closures didn't properly re-evaluate, causing the market panel to always show the initial planet's prices (Earth's Agricultural economy).

## Changes

### src/ui/web.rs
- Added `create_memo` for `current_planet_id` to track reactive planet selection
- Added `create_memo` for `current_economy` to reactively compute economy based on selected planet
- Added `create_memo` for `current_planet_type` for potential future use
- Updated `MarketPanelReactive` usage to pass memos instead of plain closures

### src/ui/market_panel.rs
- Changed `MarketPanelReactive` signature to accept `Memo<PlanetEconomy>` and `Memo<PlanetType>` instead of `Box<dyn Fn()>`
- Updated component to use `economy.get()` for reactive price lookup

## Testing

- `cargo check --features web` ✓
- `cargo test --features web` - All 228 tests passed ✓
- `trunk build` - WebAssembly build successful ✓

## Expected Behavior After Fix

| Planet Type | Cheap (supplied) | Expensive (demanded) |
|-------------|-----------------|---------------------|
| Agricultural (Earth) | Water $7, Foodstuffs $7 | Medicine $13, Firearms $13 |
| Mining (Mercury, Mars) | Metals $7, Antimatter $7 | Water $13, Foodstuffs $13 |
| Mega City (Jupiter) | Electronics $7, Medicine $7 | Water $13, Foodstuffs $13 |

Closes #118